### PR TITLE
✨ feat: Store 등록, 조회, 수정 API 개발

### DIFF
--- a/src/main/java/com/study/demo/backend/domain/store/controller/StoreController.java
+++ b/src/main/java/com/study/demo/backend/domain/store/controller/StoreController.java
@@ -1,0 +1,104 @@
+package com.study.demo.backend.domain.store.controller;
+
+import com.study.demo.backend.domain.store.converter.StoreConverter;
+import com.study.demo.backend.domain.store.dto.request.StoreReqDTO;
+import com.study.demo.backend.domain.store.dto.response.StoreResDTO;
+import com.study.demo.backend.domain.store.entity.Store;
+import com.study.demo.backend.domain.store.entity.enums.StoreSortType;
+import com.study.demo.backend.domain.store.exception.StoreErrorCode;
+import com.study.demo.backend.domain.store.exception.StoreException;
+import com.study.demo.backend.domain.store.repository.StoreRepository;
+import com.study.demo.backend.domain.store.service.command.CommandService;
+import com.study.demo.backend.domain.store.service.query.QueryService;
+import com.study.demo.backend.domain.user.entity.enums.Role;
+import com.study.demo.backend.global.apiPayload.CustomResponse;
+import com.study.demo.backend.global.apiPayload.exception.CustomException;
+import com.study.demo.backend.global.security.userdetails.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/store")
+@Tag(name = "가게 API", description = "가게 관련 API")
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreRepository storeRepository;
+
+    private final QueryService queryService;
+    private final CommandService commandService;
+
+    @PostMapping("")
+    @Operation(summary = "가게 등록 API by 최현우", description = "사용자의 Role이 OWNER인 경우 가게를 등록합니다.")
+    public CustomResponse<StoreResDTO.Create> createStore(
+            @Valid @RequestBody StoreReqDTO.Create createDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (!userDetails.getRole().equals(Role.OWNER)) {
+            throw new CustomException(StoreErrorCode.STORE_ACCESS_DENIED);
+        }
+        StoreResDTO.Create storeResDTO = commandService.createStore(createDTO);
+        return CustomResponse.onSuccess(storeResDTO);
+    }
+
+
+    @GetMapping("")
+    @Operation(summary = "가게 목록 조회 API by 최현우", description = """
+        가게 목록을 커서 기반 페이지네이션으로 조회합니다.  
+        - 정렬 기준 : 'distance(거리순)', 'review`(리뷰 많은 순)', 'discount`(할인율 순)' 
+        - cursor : 마지막으로 조회한 storeId (기본 null)  
+        - size : 조회할 데이터 수 (기본 10개)  
+        - 'lat', 'lng' : 현재 위치 좌표 (기본 상명대 위치)
+    """)
+    public CustomResponse<StoreResDTO.StoreDetailList> getStoreList(
+            @Parameter(description = "마지막으로 조회한 storeId")
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(description = "한 번에 조회할 가게 수", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+
+            @Parameter(description = "정렬 기준", example = "DISTANCE")
+            @RequestParam(defaultValue = "DISTANCE") StoreSortType type,
+
+            @Parameter(description = "현재 위도", example = "37.602")
+            @RequestParam(required = false, defaultValue = "37.602") double lat,
+
+            @Parameter(description = "현재 경도", example = "126.9565")
+            @RequestParam(required = false, defaultValue = "126.9565") double lng
+    ) {
+        StoreResDTO.StoreDetailList storeDetailList = queryService.getStoreList(cursor, size, type, lat, lng);
+        return CustomResponse.onSuccess(storeDetailList);
+    }
+
+    @GetMapping("/{storeId}")
+    @Operation(summary = "가게 상세 조회 API by 최현우", description = "가게 상세 조회")
+    public CustomResponse<StoreResDTO.StoreDetail> getStoreDetail(@PathVariable Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        StoreResDTO.StoreDetail storeDetail = StoreConverter.toStoreDetailDTO(store);
+        return CustomResponse.onSuccess(storeDetail);
+    }
+
+    @PatchMapping("/{storeId}")
+    @Operation(summary = "가게 정보 수정 API by 최현우", description = "사용자의 Role이 OWNER인 경우 가게 정보를 수정합니다.")
+    public CustomResponse<StoreResDTO.Update> updateStore(
+            @PathVariable Long storeId,
+            @Valid @RequestBody StoreReqDTO.Update updateDTO,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (!userDetails.getRole().equals(Role.OWNER)) {
+            throw new CustomException(StoreErrorCode.STORE_ACCESS_DENIED);
+        }
+        StoreResDTO.Update response = commandService.updateStore(storeId, updateDTO);
+        return CustomResponse.onSuccess(response);
+    }
+}
+

--- a/src/main/java/com/study/demo/backend/domain/store/controller/StoreController.java
+++ b/src/main/java/com/study/demo/backend/domain/store/controller/StoreController.java
@@ -13,6 +13,8 @@ import com.study.demo.backend.domain.store.service.query.QueryService;
 import com.study.demo.backend.domain.user.entity.enums.Role;
 import com.study.demo.backend.global.apiPayload.CustomResponse;
 import com.study.demo.backend.global.apiPayload.exception.CustomException;
+import com.study.demo.backend.global.security.annotation.CurrentUser;
+import com.study.demo.backend.global.security.userdetails.AuthUser;
 import com.study.demo.backend.global.security.userdetails.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,9 +41,10 @@ public class StoreController {
     @Operation(summary = "가게 등록 API by 최현우", description = "사용자의 Role이 OWNER인 경우 가게를 등록합니다.")
     public CustomResponse<StoreResDTO.Create> createStore(
             @Valid @RequestBody StoreReqDTO.Create createDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        if (!userDetails.getRole().equals(Role.OWNER)) {
+            @CurrentUser AuthUser authUser
+            ) {
+
+        if (!authUser.getRole().equals(Role.OWNER)) {
             throw new CustomException(StoreErrorCode.STORE_ACCESS_DENIED);
         }
         StoreResDTO.Create storeResDTO = commandService.createStore(createDTO);
@@ -92,9 +95,9 @@ public class StoreController {
     public CustomResponse<StoreResDTO.Update> updateStore(
             @PathVariable Long storeId,
             @Valid @RequestBody StoreReqDTO.Update updateDTO,
-            @AuthenticationPrincipal CustomUserDetails userDetails
+            @CurrentUser AuthUser authUser
     ) {
-        if (!userDetails.getRole().equals(Role.OWNER)) {
+        if (!authUser.getRole().equals(Role.OWNER)) {
             throw new CustomException(StoreErrorCode.STORE_ACCESS_DENIED);
         }
         StoreResDTO.Update response = commandService.updateStore(storeId, updateDTO);

--- a/src/main/java/com/study/demo/backend/domain/store/controller/StoreController.java
+++ b/src/main/java/com/study/demo/backend/domain/store/controller/StoreController.java
@@ -15,14 +15,12 @@ import com.study.demo.backend.global.apiPayload.CustomResponse;
 import com.study.demo.backend.global.apiPayload.exception.CustomException;
 import com.study.demo.backend.global.security.annotation.CurrentUser;
 import com.study.demo.backend.global.security.userdetails.AuthUser;
-import com.study.demo.backend.global.security.userdetails.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -55,11 +53,10 @@ public class StoreController {
     @GetMapping("")
     @Operation(summary = "가게 목록 조회 API by 최현우", description = """
         가게 목록을 커서 기반 페이지네이션으로 조회합니다.  
-        - 정렬 기준 : 'distance(거리순)', 'review`(리뷰 많은 순)', 'discount`(할인율 순)' 
-        - cursor : 마지막으로 조회한 storeId (기본 null)  
-        - size : 조회할 데이터 수 (기본 10개)  
-        - 'lat', 'lng' : 현재 위치 좌표 (기본 상명대 위치)
-    """)
+        - 정렬 기준 : 'distance(거리순)', 'review`(리뷰 많은 순)', 'discount`(할인율 순)'
+        - cursor : 마지막으로 조회한 storeId (기본 null)
+        - size : 조회할 데이터 수 (기본 10개)
+        - 'lat', 'lng' : 현재 위치 좌표 (기본 상명대 위치) """)
     public CustomResponse<StoreResDTO.StoreDetailList> getStoreList(
             @Parameter(description = "마지막으로 조회한 storeId")
             @RequestParam(required = false) Long cursor,

--- a/src/main/java/com/study/demo/backend/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/study/demo/backend/domain/store/converter/StoreConverter.java
@@ -11,8 +11,8 @@ public class StoreConverter {
     public static Store toEntity(StoreReqDTO.Create dto) {
         return Store.builder()
                 .name(dto.name())
-                .latitude(BigDecimal.valueOf(dto.latitude()))
-                .longitude(BigDecimal.valueOf(dto.longitude()))
+                .latitude(dto.latitude())
+                .longitude(dto.longitude())
                 .openingTime(dto.openingTime())
                 .closingTime(dto.closingTime())
                 .build();

--- a/src/main/java/com/study/demo/backend/domain/store/converter/StoreConverter.java
+++ b/src/main/java/com/study/demo/backend/domain/store/converter/StoreConverter.java
@@ -1,0 +1,57 @@
+package com.study.demo.backend.domain.store.converter;
+
+import com.study.demo.backend.domain.store.dto.request.StoreReqDTO;
+import com.study.demo.backend.domain.store.dto.response.StoreResDTO;
+import com.study.demo.backend.domain.store.entity.Store;
+
+import java.math.BigDecimal;
+
+public class StoreConverter {
+
+    public static Store toEntity(StoreReqDTO.Create dto) {
+        return Store.builder()
+                .name(dto.name())
+                .latitude(BigDecimal.valueOf(dto.latitude()))
+                .longitude(BigDecimal.valueOf(dto.longitude()))
+                .openingTime(dto.openingTime())
+                .closingTime(dto.closingTime())
+                .build();
+    }
+
+    public static StoreResDTO.Create toCreateDTO(Store store) {
+        return new StoreResDTO.Create(
+                store.getId(),
+                store.getName(),
+                store.getOpeningTime(),
+                store.getClosingTime(),
+                store.getLatitude(),
+                store.getLongitude(),
+                store.getCreatedAt()
+        );
+    }
+
+    public static StoreResDTO.StoreDetail toStoreDetailDTO(Store store) {
+        return StoreResDTO.StoreDetail.builder()
+                .storeId(store.getId())
+                .name(store.getName())
+                .openingTime(store.getOpeningTime())
+                .closingTime(store.getClosingTime())
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
+                .createdAt(store.getCreatedAt())
+                .build();
+    }
+
+
+    public static StoreResDTO.Update toUpdateDTO(Store store) {
+        return StoreResDTO.Update.builder()
+                .storeId(store.getId())
+                .name(store.getName())
+                .openingTime(store.getOpeningTime())
+                .closingTime(store.getClosingTime())
+                .latitude(store.getLatitude())
+                .longitude(store.getLongitude())
+                .updatedAt(store.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/store/dto/request/StoreReqDTO.java
+++ b/src/main/java/com/study/demo/backend/domain/store/dto/request/StoreReqDTO.java
@@ -13,13 +13,16 @@ public class StoreReqDTO {
 
     public record Create(
             @NotBlank(message = "가게 이름은 필수입니다.")
+            @Schema(description = "가게 이름", example = "상명김밥")
             String name,
 
             @NotNull(message = "위도는 필수입니다.")
-            Double latitude,
+            @Schema(description = "위도 (latitude), 범위: -90 ~ 90", example = "37.6005")
+            BigDecimal latitude,
 
             @NotNull(message = "경도는 필수입니다.")
-            Double longitude,
+            @Schema(description = "경도 (longitude), 범위: -180 ~ 180", example = "126.9645")
+            BigDecimal longitude,
 
             @Schema(description = "오픈 시간 (HH:mm:ss)", example = "08:00:00")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
@@ -28,8 +31,9 @@ public class StoreReqDTO {
             @Schema(description = "마감 시간 (HH:mm:ss)", example = "20:00:00")
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
             LocalTime closingTime
-    ) {
-    }
+    ) { }
+
+
 
     @Builder
     public record Update(
@@ -46,10 +50,10 @@ public class StoreReqDTO {
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
             LocalTime closingTime,
 
-            @Schema(description = "위도", example = "37.6005")
+            @Schema(description = "위도 (latitude, -90 ~ 90)", example = "37.6005")
             BigDecimal latitude,
 
-            @Schema(description = "경도", example = "126.9645")
+            @Schema(description = "경도 (longitude, -180 ~ 180)", example = "126.9645")
             BigDecimal longitude
     ) {}
 }

--- a/src/main/java/com/study/demo/backend/domain/store/dto/request/StoreReqDTO.java
+++ b/src/main/java/com/study/demo/backend/domain/store/dto/request/StoreReqDTO.java
@@ -1,0 +1,55 @@
+package com.study.demo.backend.domain.store.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+public class StoreReqDTO {
+
+    public record Create(
+            @NotBlank(message = "가게 이름은 필수입니다.")
+            String name,
+
+            @NotNull(message = "위도는 필수입니다.")
+            Double latitude,
+
+            @NotNull(message = "경도는 필수입니다.")
+            Double longitude,
+
+            @Schema(description = "오픈 시간 (HH:mm:ss)", example = "08:00:00")
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+            LocalTime openingTime,
+
+            @Schema(description = "마감 시간 (HH:mm:ss)", example = "20:00:00")
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+            LocalTime closingTime
+    ) {
+    }
+
+    @Builder
+    public record Update(
+            Long storeId,
+
+            @Schema(description = "가게 이름", example = "가게 이름")
+            String name,
+
+            @Schema(description = "오픈 시간 (HH:mm:ss)", example = "08:00:00")
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+            LocalTime openingTime,
+
+            @Schema(description = "마감 시간 (HH:mm:ss)", example = "22:00:00")
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+            LocalTime closingTime,
+
+            @Schema(description = "위도", example = "37.6005")
+            BigDecimal latitude,
+
+            @Schema(description = "경도", example = "126.9645")
+            BigDecimal longitude
+    ) {}
+}

--- a/src/main/java/com/study/demo/backend/domain/store/dto/response/StoreResDTO.java
+++ b/src/main/java/com/study/demo/backend/domain/store/dto/response/StoreResDTO.java
@@ -2,7 +2,10 @@ package com.study.demo.backend.domain.store.dto.response;
 
 import lombok.Builder;
 
+
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 public class StoreResDTO {
@@ -11,10 +14,10 @@ public class StoreResDTO {
     public record Create(
             Long storeId,
             String name,
-            java.time.LocalTime openingTime,
-            java.time.LocalTime closingTime,
-            java.math.BigDecimal latitude,
-            java.math.BigDecimal longitude,
+            LocalTime openingTime,
+            LocalTime closingTime,
+            BigDecimal latitude,
+            BigDecimal longitude,
             LocalDateTime createdAt
     ){
     }
@@ -23,10 +26,10 @@ public class StoreResDTO {
     public record StoreDetail(
             Long storeId,
             String name,
-            java.time.LocalTime openingTime,
-            java.time.LocalTime closingTime,
-            java.math.BigDecimal latitude,
-            java.math.BigDecimal longitude,
+            LocalTime openingTime,
+            LocalTime closingTime,
+            BigDecimal latitude,
+            BigDecimal longitude,
             LocalDateTime createdAt
     ) {}
 
@@ -41,11 +44,11 @@ public class StoreResDTO {
     public record Update(
             Long storeId,
             String name,
-            java.time.LocalTime openingTime,
-            java.time.LocalTime closingTime,
-            java.math.BigDecimal latitude,
-            java.math.BigDecimal longitude,
-            java.time.LocalDateTime updatedAt
+            LocalTime openingTime,
+            LocalTime closingTime,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            LocalDateTime updatedAt
     ) {}
 
 }

--- a/src/main/java/com/study/demo/backend/domain/store/dto/response/StoreResDTO.java
+++ b/src/main/java/com/study/demo/backend/domain/store/dto/response/StoreResDTO.java
@@ -1,0 +1,51 @@
+package com.study.demo.backend.domain.store.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class StoreResDTO {
+
+    @Builder
+    public record Create(
+            Long storeId,
+            String name,
+            java.time.LocalTime openingTime,
+            java.time.LocalTime closingTime,
+            java.math.BigDecimal latitude,
+            java.math.BigDecimal longitude,
+            LocalDateTime createdAt
+    ){
+    }
+
+    @Builder
+    public record StoreDetail(
+            Long storeId,
+            String name,
+            java.time.LocalTime openingTime,
+            java.time.LocalTime closingTime,
+            java.math.BigDecimal latitude,
+            java.math.BigDecimal longitude,
+            LocalDateTime createdAt
+    ) {}
+
+    // 무한 스크롤, 커서 기반 페이지네이션을 위해 필요한 데이터
+    public record StoreDetailList(
+            List<StoreDetail> stores,
+            boolean nextData,
+            Long nextCursor
+    ) {}
+
+    @Builder
+    public record Update(
+            Long storeId,
+            String name,
+            java.time.LocalTime openingTime,
+            java.time.LocalTime closingTime,
+            java.math.BigDecimal latitude,
+            java.math.BigDecimal longitude,
+            java.time.LocalDateTime updatedAt
+    ) {}
+
+}

--- a/src/main/java/com/study/demo/backend/domain/store/entity/Store.java
+++ b/src/main/java/com/study/demo/backend/domain/store/entity/Store.java
@@ -1,5 +1,6 @@
 package com.study.demo.backend.domain.store.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.study.demo.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -22,15 +23,26 @@ public class Store extends BaseEntity {
     @Column(name = "name", nullable = false)
     private String name;
 
-    @Column(name = "latitude", nullable = false)
+    @Column(name = "latitude", nullable = false, precision = 9, scale = 6)
     private BigDecimal latitude;
 
-    @Column(name = "longitude", nullable = false)
+    @Column(name = "longitude", nullable = false, precision = 9, scale = 6)
     private BigDecimal longitude;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     @Column(name = "opening_time", nullable = false)
     private LocalTime openingTime;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
     @Column(name = "closing_time", nullable = false)
     private LocalTime closingTime;
+
+    public void update(String name, BigDecimal latitude, BigDecimal longitude,
+                       LocalTime openingTime, LocalTime closingTime) {
+        this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.openingTime = openingTime;
+        this.closingTime = closingTime;
+    }
 }

--- a/src/main/java/com/study/demo/backend/domain/store/entity/enums/StoreSortType.java
+++ b/src/main/java/com/study/demo/backend/domain/store/entity/enums/StoreSortType.java
@@ -1,0 +1,5 @@
+package com.study.demo.backend.domain.store.entity.enums;
+
+public enum StoreSortType {
+    DISTANCE, REVIEW, CREATED_AT
+}

--- a/src/main/java/com/study/demo/backend/domain/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/study/demo/backend/domain/store/exception/StoreErrorCode.java
@@ -1,0 +1,25 @@
+package com.study.demo.backend.domain.store.exception;
+
+import com.study.demo.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum StoreErrorCode implements BaseErrorCode {
+
+
+    INVALID_SORT_TYPE(HttpStatus.BAD_REQUEST, "STORE400_1", "유효하지 않은 정렬 타입입니다."),
+    INVALID_LOCATION(HttpStatus.BAD_REQUEST, "STORE400_2", "위도/경도 정보가 유효하지 않습니다."),
+
+    STORE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "STORE403_0", "접근 권한(ROLE)이 없습니다."),
+
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE404_0", "요청한 가게를 찾을 수 없습니다."),
+
+    STORE_ALREADY_EXISTS(HttpStatus.CONFLICT, "STORE409_0", "이미 존재하는 가게입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/study/demo/backend/domain/store/exception/StoreException.java
+++ b/src/main/java/com/study/demo/backend/domain/store/exception/StoreException.java
@@ -1,0 +1,12 @@
+package com.study.demo.backend.domain.store.exception;
+
+import com.study.demo.backend.global.apiPayload.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class StoreException extends CustomException {
+
+    public StoreException(StoreErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/study/demo/backend/domain/store/repository/StoreRepository.java
@@ -1,0 +1,55 @@
+package com.study.demo.backend.domain.store.repository;
+
+import com.study.demo.backend.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+
+    boolean existsByName(String name);
+
+    // 최신순 정렬
+    @Query(value = """
+        SELECT * FROM store
+        WHERE (:cursor IS NULL OR id < :cursor)
+        ORDER BY created_at DESC
+        LIMIT :size
+    """, nativeQuery = true)
+    List<Store> findStoresByCreatedAt(
+            @Param("cursor") Long cursor,
+            @Param("size") int size
+    );
+
+    // 거리순 정렬(정확한 거리 계산)
+    @Query(value = """
+    SELECT * FROM store
+    WHERE (:cursor IS NULL OR id < :cursor)
+    ORDER BY ST_Distance_Sphere(
+        POINT(:lng, :lat),
+        POINT(longitude, latitude)
+    ) ASC
+    LIMIT :size
+    """, nativeQuery = true)
+    List<Store> findStoresByDistance(
+            @Param("cursor") Long cursor,
+            @Param("size") int size,
+            @Param("lat") double lat,
+            @Param("lng") double lng
+    );
+
+
+    // 리뷰순 정렬
+    @Query(value = """
+        SELECT * FROM store
+        WHERE (:cursor IS NULL OR id < :cursor)
+        ORDER BY review_count DESC, created_at DESC
+        LIMIT :size
+    """, nativeQuery = true)
+    List<Store> findStoresByReview(
+            @Param("cursor") Long cursor,
+            @Param("size") int size
+    );
+}

--- a/src/main/java/com/study/demo/backend/domain/store/service/command/CommandService.java
+++ b/src/main/java/com/study/demo/backend/domain/store/service/command/CommandService.java
@@ -1,0 +1,13 @@
+package com.study.demo.backend.domain.store.service.command;
+
+import com.study.demo.backend.domain.store.dto.request.StoreReqDTO;
+import com.study.demo.backend.domain.store.dto.response.StoreResDTO;
+import jakarta.validation.Valid;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface CommandService {
+    StoreResDTO.Create createStore(StoreReqDTO.@Valid Create createDTO);
+
+    StoreResDTO.Update updateStore(Long storeId, StoreReqDTO.@Valid Update updateDTO);
+}

--- a/src/main/java/com/study/demo/backend/domain/store/service/command/CommandServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/store/service/command/CommandServiceImpl.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -21,10 +23,16 @@ public class CommandServiceImpl implements CommandService {
 
     @Override
     public StoreResDTO.Create createStore(StoreReqDTO.@Valid Create create) {
-
-
         if (storeRepository.existsByName(create.name())) {
             throw new StoreException(StoreErrorCode.STORE_ALREADY_EXISTS);
+        }
+
+        if (create.latitude().compareTo(new BigDecimal("-90")) < 0 || create.latitude().compareTo(new BigDecimal("90")) > 0) {
+            throw new StoreException(StoreErrorCode.INVALID_LOCATION);
+        }
+
+        if (create.longitude().compareTo(new BigDecimal("-180")) < 0 || create.longitude().compareTo(new BigDecimal("180")) > 0) {
+            throw new StoreException(StoreErrorCode.INVALID_LOCATION);
         }
 
         Store store = StoreConverter.toEntity(create);
@@ -37,6 +45,18 @@ public class CommandServiceImpl implements CommandService {
     public StoreResDTO.Update updateStore(Long storeId, StoreReqDTO.@Valid Update updateDTO) {
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        if (updateDTO.latitude() != null && (
+                updateDTO.latitude().compareTo(new BigDecimal("-90")) < 0 ||
+                        updateDTO.latitude().compareTo(new BigDecimal("90")) > 0)) {
+            throw new StoreException(StoreErrorCode.INVALID_LOCATION);
+        }
+
+        if (updateDTO.longitude() != null && (
+                updateDTO.longitude().compareTo(new BigDecimal("-180")) < 0 ||
+                        updateDTO.longitude().compareTo(new BigDecimal("180")) > 0)) {
+            throw new StoreException(StoreErrorCode.INVALID_LOCATION);
+        }
 
         store.update(
                 updateDTO.name(),

--- a/src/main/java/com/study/demo/backend/domain/store/service/command/CommandServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/store/service/command/CommandServiceImpl.java
@@ -1,0 +1,51 @@
+package com.study.demo.backend.domain.store.service.command;
+
+import com.study.demo.backend.domain.store.converter.StoreConverter;
+import com.study.demo.backend.domain.store.dto.request.StoreReqDTO;
+import com.study.demo.backend.domain.store.dto.response.StoreResDTO;
+import com.study.demo.backend.domain.store.entity.Store;
+import com.study.demo.backend.domain.store.exception.StoreErrorCode;
+import com.study.demo.backend.domain.store.exception.StoreException;
+import com.study.demo.backend.domain.store.repository.StoreRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommandServiceImpl implements CommandService {
+
+    private final StoreRepository storeRepository;
+
+    @Override
+    public StoreResDTO.Create createStore(StoreReqDTO.@Valid Create create) {
+
+
+        if (storeRepository.existsByName(create.name())) {
+            throw new StoreException(StoreErrorCode.STORE_ALREADY_EXISTS);
+        }
+
+        Store store = StoreConverter.toEntity(create);
+        storeRepository.save(store);
+
+        return StoreConverter.toCreateDTO(store);
+    }
+
+    @Override
+    public StoreResDTO.Update updateStore(Long storeId, StoreReqDTO.@Valid Update updateDTO) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new StoreException(StoreErrorCode.STORE_NOT_FOUND));
+
+        store.update(
+                updateDTO.name(),
+                updateDTO.latitude(),
+                updateDTO.longitude(),
+                updateDTO.openingTime(),
+                updateDTO.closingTime()
+        );
+
+        return StoreConverter.toUpdateDTO(store);
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/store/service/query/QueryService.java
+++ b/src/main/java/com/study/demo/backend/domain/store/service/query/QueryService.java
@@ -1,0 +1,10 @@
+package com.study.demo.backend.domain.store.service.query;
+
+import com.study.demo.backend.domain.store.dto.response.StoreResDTO;
+import com.study.demo.backend.domain.store.entity.enums.StoreSortType;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface QueryService {
+    StoreResDTO.StoreDetailList getStoreList(Long cursor, int size, StoreSortType type, Double lat, Double lng);
+}

--- a/src/main/java/com/study/demo/backend/domain/store/service/query/QueryServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/store/service/query/QueryServiceImpl.java
@@ -1,0 +1,50 @@
+package com.study.demo.backend.domain.store.service.query;
+
+import com.study.demo.backend.domain.store.converter.StoreConverter;
+import com.study.demo.backend.domain.store.dto.response.StoreResDTO;
+import com.study.demo.backend.domain.store.entity.Store;
+import com.study.demo.backend.domain.store.entity.enums.StoreSortType;
+import com.study.demo.backend.domain.store.exception.StoreErrorCode;
+import com.study.demo.backend.domain.store.exception.StoreException;
+import com.study.demo.backend.domain.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class QueryServiceImpl implements QueryService {
+
+    private final StoreRepository storeRepository;
+
+    @Override
+    public StoreResDTO.StoreDetailList getStoreList(Long cursor, int size, StoreSortType type, Double lat, Double lng) {
+        List<Store> stores;
+
+        if (type == null) {
+            throw new StoreException(StoreErrorCode.INVALID_SORT_TYPE);
+        }
+
+        switch (type) {
+            case DISTANCE -> {
+                if (lat == null || lng == null) {
+                    throw new StoreException(StoreErrorCode.INVALID_LOCATION);
+                }
+                stores = storeRepository.findStoresByDistance(cursor, size, lat, lng);
+            }
+            case REVIEW -> stores = storeRepository.findStoresByReview(cursor, size);
+            case CREATED_AT -> stores = storeRepository.findStoresByCreatedAt(cursor, size);
+            default -> throw new StoreException(StoreErrorCode.INVALID_SORT_TYPE);
+        }
+
+        List<StoreResDTO.StoreDetail> dtoList = stores.stream()
+                .map(StoreConverter::toStoreDetailDTO)
+                .toList();
+
+        Long nextCursor = dtoList.isEmpty() ? null : dtoList.get(dtoList.size() - 1).storeId();
+        boolean hasNext = dtoList.size() == size;
+
+        return new StoreResDTO.StoreDetailList(dtoList, hasNext, nextCursor);
+    }
+}


### PR DESCRIPTION
# ☝️Issue Number

Close #10 

##  📌 개요
가게 등록, 가게 목록 조회, 가게 상세 조회, 가게 정보 수정 API 개발

## 🔁 변경 사항
StoreSortType Enum으로 사용하였습니다. 
가게 정렬 중 할인 순 정렬이 있었는데 가게를 할인 순으로 표현하기 어려워 우선 최신 등록 순, 거리순으로 정렬하는 기능만 구현하였습니다. 리뷰 수 정렬은 추후에 보강 하겠습니다!

## 📸 스크린샷
+ 사장님과 고객 둘의 가게 목록 조회 문제 없었습니다.
<img width="2591" height="1478" alt="스크린샷 2025-08-06 140629" src="https://github.com/user-attachments/assets/707aa33f-35ad-433e-954c-e7247f71872f" />
<img width="2535" height="874" alt="스크린샷 2025-08-06 140646" src="https://github.com/user-attachments/assets/4d784098-4888-45b2-b343-7d15d7516775" />


+ 사장님 일때만 가게 등록이 가능하도록 구현하였습니다. 일반 고객은 Role 권한 없음으로 처리 하였습니다.
<img width="1362" height="1396" alt="스크린샷 2025-08-06 151958" src="https://github.com/user-attachments/assets/32a40a42-9824-4ae1-94cf-694030b498e7" />
<img width="1296" height="604" alt="스크린샷 2025-08-06 151947" src="https://github.com/user-attachments/assets/5c0d926a-60c9-4e3b-8277-46d32c754267" />
<img width="1240" height="1208" alt="스크린샷 2025-08-06 154525" src="https://github.com/user-attachments/assets/a2dda27f-36cf-49a4-be98-2015aee6455b" />


+ 사장님과 고객 둘의 가게 상세 조회 문제 없었습니다.
<img width="1374" height="1512" alt="스크린샷 2025-08-06 152019" src="https://github.com/user-attachments/assets/8de17925-286c-4b07-87b1-db557cc1d20a" />



+ 사장님 일때만 가게 수정이 가능하도록 구현하였습니다. 일반 고객은 Role 권한 없음으로 처리 하였습니다.
<img width="1371" height="1500" alt="스크린샷 2025-08-06 152115" src="https://github.com/user-attachments/assets/77d13c0f-1b83-45a6-8658-aa63788ba784" />
<img width="1234" height="1255" alt="스크린샷 2025-08-06 154553" src="https://github.com/user-attachments/assets/6926c660-73a7-4d47-8bfd-39068768aaa3" />

## 👀 기타 더 이야기해볼 점
가게 생성과 수정에서 Role을 확인하는 경우 ``` @PreAuthorize("hasRole('OWNER')") ```와 ``` @EnableGlobalMethodSecurity ```을 사용하는게 좋은지 이야기 나누고 싶습니다!

