### PR TITLE
✨feat: 장바구니 API 개발

### DIFF
--- a/src/main/java/com/study/demo/backend/domain/cart/controller/CartController.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/controller/CartController.java
@@ -1,0 +1,36 @@
+package com.study.demo.backend.domain.cart.controller;
+
+import com.study.demo.backend.domain.cart.dto.requset.CartReqDTO;
+import com.study.demo.backend.domain.cart.dto.response.CartResDTO;
+import com.study.demo.backend.domain.cart.service.command.CartCommandService;
+import com.study.demo.backend.domain.cart.service.query.CartQueryService;
+import com.study.demo.backend.global.apiPayload.CustomResponse;
+import com.study.demo.backend.global.security.annotation.CurrentUser;
+import com.study.demo.backend.global.security.userdetails.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/carts")
+@Tag(name = "장바구니 API", description = "장바구니 관련 API")
+public class CartController {
+
+    private final CartCommandService cartCommandService;
+    private final CartQueryService cartQueryService;
+
+    @PostMapping("")
+    @Operation(summary = "장바구니 생성/메뉴추가 API by 김지명", description = "장바구니를 생성하여 메뉴를 추가합니다.")
+    public CustomResponse<CartResDTO.AddMenu> addMenuToCart(@RequestBody CartReqDTO.AddMenu reqDTO,
+                                                            @CurrentUser AuthUser authUser) {
+        CartResDTO.AddMenu resDTO = cartCommandService.addMenuToCart(reqDTO, authUser);
+        return CustomResponse.onSuccess(resDTO);
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/controller/CartController.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/controller/CartController.java
@@ -11,10 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
@@ -28,9 +25,16 @@ public class CartController {
 
     @PostMapping("")
     @Operation(summary = "장바구니 생성/메뉴추가 API by 김지명", description = "장바구니를 생성하여 메뉴를 추가합니다.")
-    public CustomResponse<CartResDTO.AddMenu> addMenuToCart(@RequestBody CartReqDTO.AddMenu reqDTO,
-                                                            @CurrentUser AuthUser authUser) {
-        CartResDTO.AddMenu resDTO = cartCommandService.addMenuToCart(reqDTO, authUser);
+    public CustomResponse<CartResDTO.CartInfo> addMenuToCart(@RequestBody CartReqDTO.AddMenu reqDTO,
+                                                             @CurrentUser AuthUser authUser) {
+        CartResDTO.CartInfo resDTO = cartCommandService.addMenuToCart(reqDTO, authUser);
+        return CustomResponse.onSuccess(resDTO);
+    }
+
+    @GetMapping("")
+    @Operation(summary = "장바구니 조회 API by 김지명", description = "장바구니를 조회합니다.")
+    public CustomResponse<CartResDTO.CartInfo> getCartInfo(@CurrentUser AuthUser authUser) {
+        CartResDTO.CartInfo resDTO = cartQueryService.getCartInfo(authUser);
         return CustomResponse.onSuccess(resDTO);
     }
 }

--- a/src/main/java/com/study/demo/backend/domain/cart/converter/CartConverter.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/converter/CartConverter.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CartConverter {
 
-    public static CartResDTO.AddMenu toAddMenuResponse(Cart cart, List<CartMenu> cartMenus) {
+    public static CartResDTO.CartInfo toCartInfo(Cart cart, List<CartMenu> cartMenus) {
         List<CartResDTO.CartMenuInfo> cartMenuInfoList = cartMenus.stream()
                 .map(cm -> new CartResDTO.CartMenuInfo(
                         cm.getMenu().getStore().getId(),
@@ -22,7 +22,7 @@ public class CartConverter {
                 ))
                 .collect(Collectors.toList());
 
-        return CartResDTO.AddMenu.builder()
+        return CartResDTO.CartInfo.builder()
                 .cartId(cart.getId())
                 .cartMenuInfoList(cartMenuInfoList)
                 .build();

--- a/src/main/java/com/study/demo/backend/domain/cart/converter/CartConverter.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/converter/CartConverter.java
@@ -1,0 +1,30 @@
+package com.study.demo.backend.domain.cart.converter;
+
+import com.study.demo.backend.domain.cart.dto.response.CartResDTO;
+import com.study.demo.backend.domain.cart.entity.Cart;
+import com.study.demo.backend.domain.cart.entity.CartMenu;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CartConverter {
+
+    public static CartResDTO.AddMenu toAddMenuResponse(Cart cart, List<CartMenu> cartMenus) {
+        List<CartResDTO.CartMenuInfo> cartMenuInfoList = cartMenus.stream()
+                .map(cm -> new CartResDTO.CartMenuInfo(
+                        cm.getMenu().getStore().getId(),
+                        cm.getMenu().getId(),
+                        cm.getMenu().getName(),
+                        cm.getQuantity()
+                ))
+                .collect(Collectors.toList());
+
+        return CartResDTO.AddMenu.builder()
+                .cartId(cart.getId())
+                .cartMenuInfoList(cartMenuInfoList)
+                .build();
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/dto/requset/CartReqDTO.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/dto/requset/CartReqDTO.java
@@ -1,0 +1,10 @@
+package com.study.demo.backend.domain.cart.dto.requset;
+
+public class CartReqDTO {
+
+    public record AddMenu(
+            Long menuId,
+            int quantity
+    ) {
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/dto/response/CartResDTO.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/dto/response/CartResDTO.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class CartResDTO {
 
     @Builder
-    public record AddMenu(
+    public record CartInfo(
             Long cartId,
             List<CartMenuInfo> cartMenuInfoList
     ) {

--- a/src/main/java/com/study/demo/backend/domain/cart/dto/response/CartResDTO.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/dto/response/CartResDTO.java
@@ -1,0 +1,23 @@
+package com.study.demo.backend.domain.cart.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public class CartResDTO {
+
+    @Builder
+    public record AddMenu(
+            Long cartId,
+            List<CartMenuInfo> cartMenuInfoList
+    ) {
+    }
+
+    public record CartMenuInfo(
+            Long storeId,
+            Long menuId,
+            String menuName,
+            int quantity
+    ) {
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/entity/CartMenu.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/entity/CartMenu.java
@@ -27,4 +27,11 @@ public class CartMenu {
 
     @Column(name = "quantity", nullable = false)
     private int quantity;
+
+    public void setQuantity(int q) {
+        if (q <= 0) {
+            throw new IllegalArgumentException("quantity must be positive");
+        }
+        this.quantity = q;
+    }
 }

--- a/src/main/java/com/study/demo/backend/domain/cart/exception/CartErrorCode.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/exception/CartErrorCode.java
@@ -1,0 +1,20 @@
+package com.study.demo.backend.domain.cart.exception;
+
+import com.study.demo.backend.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CartErrorCode implements BaseErrorCode {
+
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "CART404_0","장바구니가 없습니다."),
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "CART404_1","메뉴를 찾을 수 없습니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "CART400_0","수량은 1 이상이어야 합니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/exception/CartException.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/exception/CartException.java
@@ -1,0 +1,13 @@
+package com.study.demo.backend.domain.cart.exception;
+
+import com.study.demo.backend.domain.review.exception.ReviewErrorCode;
+import com.study.demo.backend.global.apiPayload.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class CartException extends CustomException {
+
+    public CartException(CartErrorCode errorCode){
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/repository/CartMenuRepository.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/repository/CartMenuRepository.java
@@ -26,4 +26,13 @@ public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from CartMenu cm where cm.cart.id = :cartId")
     void deleteByCartId(@Param("cartId") Long cartId);
+
+    @Query("""
+       select cm
+       from CartMenu cm
+       join fetch cm.menu m
+       join fetch m.store s
+       where cm.cart.id = :cartId
+       """)
+    List<CartMenu> findByCartIdWithMenuAndStore(@Param("cartId") Long cartId);
 }

--- a/src/main/java/com/study/demo/backend/domain/cart/repository/CartMenuRepository.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/repository/CartMenuRepository.java
@@ -1,0 +1,29 @@
+package com.study.demo.backend.domain.cart.repository;
+
+import com.study.demo.backend.domain.cart.entity.CartMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CartMenuRepository extends JpaRepository<CartMenu, Long> {
+    List<CartMenu> findByCartId(Long cartId);
+
+    Optional<CartMenu> findByCartIdAndMenuId(Long cartId, Long menuId);
+
+    @Query("""
+           select m.store.id
+           from CartMenu cm
+           join cm.menu m
+           where cm.cart.id = :cartId
+           group by m.store.id
+           """)
+    List<Long> findDistinctStoreIdsByCartId(@Param("cartId") Long cartId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("delete from CartMenu cm where cm.cart.id = :cartId")
+    void deleteByCartId(@Param("cartId") Long cartId);
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/repository/CartRepository.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/repository/CartRepository.java
@@ -1,0 +1,10 @@
+package com.study.demo.backend.domain.cart.repository;
+
+import com.study.demo.backend.domain.cart.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+    Optional<Cart> findByUserId(Long userId);
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/service/command/CartCommandService.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/service/command/CartCommandService.java
@@ -1,0 +1,9 @@
+package com.study.demo.backend.domain.cart.service.command;
+
+import com.study.demo.backend.domain.cart.dto.requset.CartReqDTO;
+import com.study.demo.backend.domain.cart.dto.response.CartResDTO;
+import com.study.demo.backend.global.security.userdetails.AuthUser;
+
+public interface CartCommandService {
+    CartResDTO.AddMenu addMenuToCart(CartReqDTO.AddMenu reqDTO, AuthUser authUser);
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/service/command/CartCommandService.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/service/command/CartCommandService.java
@@ -5,5 +5,5 @@ import com.study.demo.backend.domain.cart.dto.response.CartResDTO;
 import com.study.demo.backend.global.security.userdetails.AuthUser;
 
 public interface CartCommandService {
-    CartResDTO.AddMenu addMenuToCart(CartReqDTO.AddMenu reqDTO, AuthUser authUser);
+    CartResDTO.CartInfo addMenuToCart(CartReqDTO.AddMenu reqDTO, AuthUser authUser);
 }

--- a/src/main/java/com/study/demo/backend/domain/cart/service/command/CartCommandServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/service/command/CartCommandServiceImpl.java
@@ -1,0 +1,74 @@
+package com.study.demo.backend.domain.cart.service.command;
+
+import com.study.demo.backend.domain.cart.converter.CartConverter;
+import com.study.demo.backend.domain.cart.dto.requset.CartReqDTO;
+import com.study.demo.backend.domain.cart.dto.response.CartResDTO;
+import com.study.demo.backend.domain.cart.entity.Cart;
+import com.study.demo.backend.domain.cart.entity.CartMenu;
+import com.study.demo.backend.domain.cart.exception.CartErrorCode;
+import com.study.demo.backend.domain.cart.exception.CartException;
+import com.study.demo.backend.domain.cart.repository.CartMenuRepository;
+import com.study.demo.backend.domain.cart.repository.CartRepository;
+import com.study.demo.backend.domain.menu.entity.Menu;
+import com.study.demo.backend.domain.menu.repository.MenuRepository;
+import com.study.demo.backend.domain.user.entity.User;
+import com.study.demo.backend.domain.user.exception.UserErrorCode;
+import com.study.demo.backend.domain.user.exception.UserException;
+import com.study.demo.backend.domain.user.repository.UserRepository;
+import com.study.demo.backend.global.security.userdetails.AuthUser;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CartCommandServiceImpl implements CartCommandService {
+
+    private final UserRepository userRepository;
+    private final CartRepository cartRepository;
+    private final MenuRepository menuRepository;
+    private final CartMenuRepository cartMenuRepository;
+
+    @Override
+    @Transactional
+    public CartResDTO.AddMenu addMenuToCart(CartReqDTO.AddMenu reqDTO, AuthUser authUser) {
+        User user = userRepository.findByEmail(authUser.getEmail())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Cart cart = cartRepository.findByUserId(user.getId())
+                .orElseGet(() -> cartRepository.save(
+                        Cart.builder().user(user).build()
+                ));
+
+        Menu menu = menuRepository.findById(reqDTO.menuId())
+                .orElseThrow(() -> new CartException(CartErrorCode.MENU_NOT_FOUND));
+
+        Long newStoreId = menu.getStore().getId();
+
+        // 기존 카트의 가게와 비교
+        List<Long> storeIds = cartMenuRepository.findDistinctStoreIdsByCartId(cart.getId());
+        if (!storeIds.isEmpty() && (storeIds.size() > 1 || !storeIds.get(0).equals(newStoreId))) {
+            cartMenuRepository.deleteByCartId(cart.getId()); // 비우기
+        }
+
+        // 동일 메뉴 있으면 가져오고, 없으면 생성(초기 quantity=0)
+        CartMenu cartMenu = cartMenuRepository.findByCartIdAndMenuId(cart.getId(), menu.getId())
+                .orElseGet(() -> cartMenuRepository.save(
+                        CartMenu.builder()
+                                .cart(cart)
+                                .menu(menu)
+                                .quantity(0)
+                                .build()
+                ));
+
+        // 수량 "설정"
+        cartMenu.setQuantity(reqDTO.quantity());
+
+        List<CartMenu> items = cartMenuRepository.findByCartId(cart.getId());
+        return CartConverter.toAddMenuResponse(cart, items);
+    }
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/service/command/CartCommandServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/service/command/CartCommandServiceImpl.java
@@ -35,7 +35,7 @@ public class CartCommandServiceImpl implements CartCommandService {
 
     @Override
     @Transactional
-    public CartResDTO.AddMenu addMenuToCart(CartReqDTO.AddMenu reqDTO, AuthUser authUser) {
+    public CartResDTO.CartInfo addMenuToCart(CartReqDTO.AddMenu reqDTO, AuthUser authUser) {
         User user = userRepository.findByEmail(authUser.getEmail())
                 .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
@@ -69,6 +69,6 @@ public class CartCommandServiceImpl implements CartCommandService {
         cartMenu.setQuantity(reqDTO.quantity());
 
         List<CartMenu> items = cartMenuRepository.findByCartId(cart.getId());
-        return CartConverter.toAddMenuResponse(cart, items);
+        return CartConverter.toCartInfo(cart, items);
     }
 }

--- a/src/main/java/com/study/demo/backend/domain/cart/service/query/CartQueryService.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/service/query/CartQueryService.java
@@ -1,0 +1,4 @@
+package com.study.demo.backend.domain.cart.service.query;
+
+public interface CartQueryService {
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/service/query/CartQueryService.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/service/query/CartQueryService.java
@@ -1,4 +1,8 @@
 package com.study.demo.backend.domain.cart.service.query;
 
+import com.study.demo.backend.domain.cart.dto.response.CartResDTO;
+import com.study.demo.backend.global.security.userdetails.AuthUser;
+
 public interface CartQueryService {
+    CartResDTO.CartInfo getCartInfo(AuthUser authUser);
 }

--- a/src/main/java/com/study/demo/backend/domain/cart/service/query/CartQueryServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/service/query/CartQueryServiceImpl.java
@@ -1,0 +1,11 @@
+package com.study.demo.backend.domain.cart.service.query;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CartQueryServiceImpl implements CartQueryService {
+}

--- a/src/main/java/com/study/demo/backend/domain/cart/service/query/CartQueryServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/cart/service/query/CartQueryServiceImpl.java
@@ -1,11 +1,43 @@
 package com.study.demo.backend.domain.cart.service.query;
 
+import com.study.demo.backend.domain.cart.converter.CartConverter;
+import com.study.demo.backend.domain.cart.dto.response.CartResDTO;
+import com.study.demo.backend.domain.cart.entity.Cart;
+import com.study.demo.backend.domain.cart.entity.CartMenu;
+import com.study.demo.backend.domain.cart.exception.CartErrorCode;
+import com.study.demo.backend.domain.cart.exception.CartException;
+import com.study.demo.backend.domain.cart.repository.CartMenuRepository;
+import com.study.demo.backend.domain.cart.repository.CartRepository;
+import com.study.demo.backend.domain.user.entity.User;
+import com.study.demo.backend.domain.user.exception.UserErrorCode;
+import com.study.demo.backend.domain.user.exception.UserException;
+import com.study.demo.backend.domain.user.repository.UserRepository;
+import com.study.demo.backend.global.security.userdetails.AuthUser;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CartQueryServiceImpl implements CartQueryService {
+
+    private final UserRepository userRepository;
+    private final CartRepository cartRepository;
+    private final CartMenuRepository cartMenuRepository;
+
+    @Override
+    public CartResDTO.CartInfo getCartInfo(AuthUser authUser) {
+        User user = userRepository.findByEmail(authUser.getEmail())
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+
+        Cart cart = cartRepository.findByUserId(user.getId())
+                .orElseThrow(() -> new CartException(CartErrorCode.CART_NOT_FOUND));
+
+        List<CartMenu> cartMenuList = cartMenuRepository.findByCartIdWithMenuAndStore(cart.getId());
+
+        return CartConverter.toCartInfo(cart, cartMenuList);
+    }
 }

--- a/src/main/java/com/study/demo/backend/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/study/demo/backend/domain/menu/repository/MenuRepository.java
@@ -1,0 +1,7 @@
+package com.study.demo.backend.domain.menu.repository;
+
+import com.study.demo.backend.domain.menu.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+}

--- a/src/main/java/com/study/demo/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/study/demo/backend/domain/review/controller/ReviewController.java
@@ -54,6 +54,7 @@ public class ReviewController {
     }
 
     @GetMapping("/{storeId}/summary")
+    @Operation(summary = "GPT 리뷰 요약 API by 김지명", description = "GPT가 리뷰를 요약해줍니다.")
     public CustomResponse<ReviewResDTO.Summary> getSummaryByStore(@PathVariable Long storeId) {
         return CustomResponse.onSuccess(reviewQueryService.summarizeReviewsByStore(storeId));
     }

--- a/src/main/java/com/study/demo/backend/global/apiPayload/CustomResponse.java
+++ b/src/main/java/com/study/demo/backend/global/apiPayload/CustomResponse.java
@@ -1,5 +1,6 @@
 package com.study.demo.backend.global.apiPayload;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AccessLevel;
@@ -20,6 +21,7 @@ public class CustomResponse<T> {
     private String message;
 
     @JsonProperty("result")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T result;
 
     //기본적으로 200 OK를 사용하는 성공 응답 생성 메서드
@@ -30,6 +32,10 @@ public class CustomResponse<T> {
     //상태 코드를 받아서 사용하는 성공 응답 생성 메서드
     public static <T> CustomResponse<T> onSuccess(HttpStatus status, T result) {
         return new CustomResponse<>(true, String.valueOf(status.value()), status.getReasonPhrase(), result);
+    }
+
+    public static <T> CustomResponse<T> onSuccess(T result, String message) {
+        return new CustomResponse<>(true, String.valueOf(HttpStatus.OK.value()), message, result);
     }
 
     //실패 응답 생성 메서드 (데이터 포함)


### PR DESCRIPTION
# ☝️Issue Number

Close #13 

##  📌 개요
장바구니 생성/메뉴추가 API
- 기존에 있던 메뉴의 storeId와 다르면 삭제하고 새로운 가게의 메뉴만 추가되게 로직 짜놨습니다.

장바구니 조회 API

## 🔁 변경 사항

## 📸 스크린샷
### 장바구니 생성/메뉴추가 API
<img width="1419" height="669" alt="image" src="https://github.com/user-attachments/assets/961490e2-12e3-49a1-8a98-956aa5822129" />
<img width="1408" height="546" alt="image" src="https://github.com/user-attachments/assets/dd654ef9-ed84-4433-ba42-8c87905f4780" />

### 장바구니 조회 API
<img width="1417" height="957" alt="image" src="https://github.com/user-attachments/assets/9a4582a7-b273-4e4b-b9d4-ebb7d8f45ec3" />


## 👀 기타 더 이야기해볼 점
