### PR TITLE
✨ feat: Menu AI 설명 기능 추가 & Menu 삭제 리펙토링

### DIFF
--- a/src/main/java/com/study/demo/backend/domain/menu/dto/request/MenuReqDTO.java
+++ b/src/main/java/com/study/demo/backend/domain/menu/dto/request/MenuReqDTO.java
@@ -60,10 +60,17 @@ public class MenuReqDTO {
         ) {
         }
 
-        @Schema(name = "값 증감 요청")
+        @Schema(name = "값 증감 요청 DTO")
         public record ValueUpdate(
                 @NotNull
                 @Schema(description = "+1이면 증가, -1이면 감소", example = "1")
                 Integer changedValue
+        ) {}
+
+        @Schema(name = "AI 메뉴 설명 생성을 위한 요청 DTO")
+        public record GenerateDescription(
+                @NotBlank(message = "메뉴 이름은 필수 입력값입니다.")
+                @Schema(description = "메뉴 이름", example = "포테이토 피자")
+                String menuName
         ) {}
 }

--- a/src/main/java/com/study/demo/backend/domain/menu/exception/MenuErrorCode.java
+++ b/src/main/java/com/study/demo/backend/domain/menu/exception/MenuErrorCode.java
@@ -14,14 +14,16 @@ public enum MenuErrorCode implements BaseErrorCode {
     INVALID_PRICE(HttpStatus.BAD_REQUEST, "MENU400_2", "유효하지 않은 가격입니다."),
     INVALID_DISCOUNT_PERCENT(HttpStatus.BAD_REQUEST, "MENU400_3", "할인율은 0~100 사이 값 입니다."),
     INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "MENU400_4","잘못된 수량 값 입니다." ),
-
+    MENU_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "MENU400_5", "메뉴 이미지는 필수 첨부 파일입니다."),
 
     MENU_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MENU403_0", "접근 권한(ROLE)이 없습니다."),
 
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU404_0", "요청한 메뉴가 존재하지 않습니다."),
     MENU_STORE_MISMATCH(HttpStatus.NOT_FOUND, "MENU404_1", "해당 가게에 존재하지 않는 메뉴입니다."),
 
-    MENU_ALREADY_EXISTS(HttpStatus.CONFLICT, "MENU409_0", "이미 존재하는 메뉴입니다.");
+    MENU_ALREADY_EXISTS(HttpStatus.CONFLICT, "MENU409_0", "이미 존재하는 메뉴입니다."),
+
+    AI_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "MENU500-001", "AI 메뉴 설명 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/study/demo/backend/domain/menu/service/command/GPTImgService.java
+++ b/src/main/java/com/study/demo/backend/domain/menu/service/command/GPTImgService.java
@@ -1,0 +1,8 @@
+package com.study.demo.backend.domain.menu.service.command;
+
+import com.study.demo.backend.domain.menu.dto.request.MenuReqDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface GPTImgService {
+    String generateDescription(MenuReqDTO.GenerateDescription request, MultipartFile menuImage);
+}

--- a/src/main/java/com/study/demo/backend/domain/menu/service/command/GPTImgServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/menu/service/command/GPTImgServiceImpl.java
@@ -1,0 +1,107 @@
+package com.study.demo.backend.domain.menu.service.command;
+
+import com.study.demo.backend.domain.menu.dto.request.MenuReqDTO;
+import com.study.demo.backend.domain.menu.exception.MenuErrorCode;
+import com.study.demo.backend.domain.review.dto.response.ReviewResDTO;
+import com.study.demo.backend.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GPTImgServiceImpl implements GPTImgService {
+
+    @Qualifier("openaiWebClient")
+    private final WebClient openaiWebClient;
+
+    @Value("${openai.model}")
+    private String model;
+
+    @Override
+    public String generateDescription(MenuReqDTO.GenerateDescription request, MultipartFile menuImage) {
+        log.info("AI 설명 생성 요청 수신. 파일명: {}, 타입: {}, 크기: {} bytes",
+                menuImage.getOriginalFilename(), menuImage.getContentType(),menuImage.getSize());
+
+        if (menuImage == null || menuImage.isEmpty()) {
+            throw new CustomException(MenuErrorCode.MENU_IMAGE_REQUIRED);
+        }
+
+        try {
+            String base64Image = encodeImageToBase64(menuImage);
+            String contentType = menuImage.getContentType();
+
+            Map<String, Object> body = createBody(request.menuName(), base64Image, contentType);
+
+            return openaiWebClient.post()
+                    .uri("/chat/completions")
+                    .bodyValue(body)
+                    .retrieve()
+                    .bodyToMono(ReviewResDTO.GPTResponse.class)
+                    .map(res -> res.choices().get(0).message().content().trim())
+                    .onErrorReturn("이미지 설명 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
+                    .block();
+
+        } catch (IOException e) {
+            log.error("이미지 파일을 Base64로 인코딩하는 데 실패했습니다.", e);
+            throw new RuntimeException("이미지 처리 중 서버 내부 오류가 발생했습니다.", e);
+        } catch (Exception e) {
+            log.warn("OpenAI Vision API 호출 중 예외가 발생했습니다.", e);
+            return "이미지 설명 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+        }
+    }
+
+    private String encodeImageToBase64(MultipartFile imageFile) throws IOException {
+        byte[] imageBytes = imageFile.getBytes();
+        return Base64.getEncoder().encodeToString(imageBytes);
+    }
+
+    private Map<String, Object> createBody(String menuName, String base64Image, String contentType) {
+        String promptText = """
+            [역할]
+            당신은 고객의 입맛을 돋우는 전문 메뉴 카피라이터입니다.
+            
+            [임무]
+            아래 [메뉴 이름]과 [이미지]를 보고, 고객이 주문하고 싶게 만드는 매력적인 메뉴 설명을 생성해주세요.
+            
+            [작성 규칙]
+            - 친근하면서도 전문성이 느껴지는 톤을 유지해주세요.
+            - 메뉴의 핵심 재료, 맛, 식감을 중심으로 1~2문장의 간결한 한국어로 작성해주세요.
+            - 고객의 오감을 자극하는 표현을 사용해주세요. (예: '바삭한', '육즙 가득한', '싱싱한', '건강한', '두툼한')
+            - 사진에서 보이지 않는 재료를 상상해서 쓰지 마세요.
+            - 메뉴 이름만 단순히 반복해서 설명하지 마세요.
+            - 너무 전문적이거나 어려운 요리 용어는 피해주세요.
+            
+            [예외 처리]
+            - 만약 제공된 이미지가 음식이 아니거나 메뉴를 설명하기에 부적절하다면, 다른 말 없이 오직 "메뉴 설명을 생성할 수 없는 이미지입니다." 라고만 답변해주세요.
+            
+            [메뉴 이름]
+            %s
+            """.formatted(menuName);
+
+        return Map.of(
+                "model", model,
+                "messages", List.of(
+                        Map.of("role", "user", "content", List.of(
+                                Map.of("type", "text", "text", promptText),
+                                Map.of(
+                                        "type", "image_url",
+                                        "image_url", Map.of("url", "data:%s;base64,%s".formatted(contentType, base64Image))
+                                )
+                        ))
+                ),
+                "max_tokens", 200 // 설명이 조금 길어질 수 있으니 넉넉하게 설정
+        );
+    }
+}

--- a/src/main/java/com/study/demo/backend/global/ImgUploader/LocalUploader.java
+++ b/src/main/java/com/study/demo/backend/global/ImgUploader/LocalUploader.java
@@ -29,33 +29,27 @@ public class LocalUploader implements FileUploader {
         if (file == null || file.isEmpty()) return null;
 
         try {
-            // 1) 저장 디렉토리 생성
             Path saveDir = Paths.get(uploadRoot, dir).toAbsolutePath().normalize();
             Files.createDirectories(saveDir);
 
-            // 2) 파일명/확장자 안전 처리
             String original = file.getOriginalFilename();
             String ext = "";
             if (original != null) {
                 int dot = original.lastIndexOf('.');
                 if (dot >= 0 && dot < original.length() - 1) {
-                    ext = original.substring(dot); // ".jpg"
+                    ext = original.substring(dot);
                 }
             }
             String savedName = UUID.randomUUID() + ext;
 
-            // 3) 안전한 저장: transferTo 대신 NIO copy (간헐적 이슈 방지)
             Path target = saveDir.resolve(savedName);
             try (InputStream in = file.getInputStream()) {
                 Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
             }
 
-            // 4) 브라우저에서 접근할 공개 경로 반환
             return publicPrefix + "/" + dir + "/" + savedName;
 
         } catch (Exception e) {
-            // 원인 로그 남기기
-            // (SLF4J 사용)
             log.error("Local upload failed: root={}, dir={}, size={}, contentType={}, reason={}",
                     uploadRoot, dir, file.getSize(), file.getContentType(), e.getMessage(), e);
             throw new RuntimeException("로컬 이미지 업로드 실패", e);

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -12,6 +12,11 @@ spring:
     hibernate:
       ddl-auto: update
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 100MB
+
   data:
     redis:
       host: localhost
@@ -22,6 +27,11 @@ spring:
     token:
       access-expiration-time: 3600000
       refresh-expiration-time: 2592000000
+
+file:
+  upload:
+    root: ./uploads
+    public-prefix: /uploads
 
 webclient:
   connection-timeout: 5000

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -12,6 +12,11 @@ spring:
     hibernate:
       ddl-auto: update
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 100MB
+
   data:
     redis:
       host: localhost


### PR DESCRIPTION
# ☝️Issue Number

Close #21 

##  📌 개요

- Menu AI 설명 기능 추가 & Menu 삭제 리펙토링


메뉴 추가와 수정 페이지에서 AI 설명 추가 버튼을 눌렀을 때 입력된 메뉴 이름과 사진을 필수로 하여 AI 설명을 만들도록 하였습니다. 
메뉴 이름과 사진이 일치하지 않는 경우, 사진이 음식이 아닌 경우 "메뉴 설명을 생성할 수 없는 이미지입니다."를 반환하도록 하였습니다.    
반환값으로 String 반환하도록 하였습니다. 반환 값을 사장님이 직접 수정 할 수 있도록 하기 위해서 바로 DB 저장되지 않도록 설계 하였습니다.

- OpenAI API key 이전 프로젝트에 사용하던 게 있어서 그것 이용해서 테스트했습니다.

## 🔁 변경 사항
- 삭제 로직에서 가장 중요한 삭제 부분이 빠져있었습니닷! 추가하고 테스트 완료하였습니다!

## 📸 스크린샷
- 메뉴 AI 설명 결과입니다.

<img width="1366" height="1466" alt="스크린샷 2025-08-14 023547" src="https://github.com/user-attachments/assets/d552e026-8bc6-4313-ab3c-a914865635fa" />


- 메뉴 이름과 이미지가 불일치하는 경우입니다. (왕 큰 햄버거랑 피자 사진넣어서 테스트했습니다.)
<img width="1918" height="1450" alt="image" src="https://github.com/user-attachments/assets/6941b99a-336e-4804-b2b1-9b0864a6cfff" />

- 메뉴 삭제
<img width="1916" height="1318" alt="image" src="https://github.com/user-attachments/assets/d7c50180-a8cd-4434-aa8e-1418420f9aa9" />
<img width="1915" height="1335" alt="image" src="https://github.com/user-attachments/assets/81c35462-e482-4b4a-86a6-bad9976a3272" />



## 👀 기타 더 이야기해볼 점
