### PR TITLE
♻️refactor: GPT 리뷰 요약에 Redis 캐시 적용

### DIFF
--- a/src/main/java/com/study/demo/backend/domain/review/service/command/GPTServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/review/service/command/GPTServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 

--- a/src/main/java/com/study/demo/backend/domain/review/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/study/demo/backend/domain/review/service/query/ReviewQueryServiceImpl.java
@@ -9,6 +9,7 @@ import com.study.demo.backend.domain.review.repository.ReviewRepository;
 import com.study.demo.backend.domain.review.service.command.GPTService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -59,6 +60,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     }
 
     @Override
+    @Cacheable(value = "summary", key = "#storeId")
     public ReviewResDTO.Summary summarizeReviewsByStore(Long storeId) {
         List<Review> reviews = reviewRepository.findAllByStoreIdOrderByReviewDateAtDesc(storeId);
         List<String> contents = reviews.stream().map(Review::getContent).toList();

--- a/src/main/java/com/study/demo/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/study/demo/backend/global/config/RedisConfig.java
@@ -1,14 +1,22 @@
 package com.study.demo.backend.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
+@EnableCaching
 @Configuration
 public class RedisConfig {
 
@@ -30,6 +38,16 @@ public class RedisConfig {
         redisTemplate.setKeySerializer(new StringRedisSerializer()); // Redis 키 직렬화 설정
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer()); // Redis 값 직렬화 설정
         return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(60)); // 캐시 수명 1시간
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(connectionFactory).cacheDefaults(redisCacheConfiguration).build();
     }
 
 }


### PR DESCRIPTION
# ☝️Issue Number

Close #29 

##  📌 개요

GPT 리뷰 요약에 Redis 캐시 적용

## 🔁 변경 사항

## 📸 스크린샷
### 기존 응답 속도
<img width="722" height="554" alt="image" src="https://github.com/user-attachments/assets/761d5545-813a-4737-a58c-f7ca51abd633" />

### 캐시 적용 후 첫번째 요청
<img width="747" height="349" alt="image" src="https://github.com/user-attachments/assets/ad5c2e95-8e1a-4ba8-a221-c687c86499c2" />

### 캐시 적용 후 첫번째 요청 이후 요청
<img width="734" height="343" alt="image" src="https://github.com/user-attachments/assets/3a56f20f-fa09-4299-9e94-2eaccce91df7" />

기존 3.52s -> 적용 후 36ms로 성능 최적화

캐시의 TTL은 1시간으로 설정

## 👀 기타 더 이야기해볼 점
