### PR TITLE
♻️ refactor: 이미지 저장 경로 수정

### DIFF
--- a/src/main/java/com/study/demo/backend/global/ImgUploader/LocalUploader.java
+++ b/src/main/java/com/study/demo/backend/global/ImgUploader/LocalUploader.java
@@ -1,12 +1,10 @@
 package com.study.demo.backend.global.ImgUploader;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.beans.factory.annotation.Value;
 
-import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,6 +21,9 @@ public class LocalUploader implements FileUploader {
 
     @Value("${file.upload.public-prefix:/uploads}")
     private String publicPrefix;
+
+    @Value("${file.upload.domain}")
+    private String domain;
 
     @Override
     public String upload(MultipartFile file, String dir) {
@@ -47,7 +48,9 @@ public class LocalUploader implements FileUploader {
                 Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
             }
 
-            return publicPrefix + "/" + dir + "/" + savedName;
+            String base = domain.endsWith("/") ? domain.substring(0, domain.length() - 1) : domain;
+            String prefix = publicPrefix.startsWith("/") ? publicPrefix : "/" + publicPrefix;
+            return base + prefix + "/" + dir + "/" + savedName;
 
         } catch (Exception e) {
             log.error("Local upload failed: root={}, dir={}, size={}, contentType={}, reason={}",

--- a/src/main/resources/application-develop.yml
+++ b/src/main/resources/application-develop.yml
@@ -32,6 +32,7 @@ file:
   upload:
     root: ./uploads
     public-prefix: /uploads
+    domain: ${FILE_UPLOAD_DOMAIN:https://api-whynotbuy.store}
 
 webclient:
   connection-timeout: 5000

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -32,6 +32,7 @@ file:
   upload:
     root: ./uploads
     public-prefix: /uploads
+    domain: ${FILE_UPLOAD_DOMAIN:http://localhost:8080}
 
 discord:
   webhook:


### PR DESCRIPTION
# ☝️Issue Number

Close #49 

##  📌 개요

- 이미지 저장 경로에 배포 링크 적어서 DB에 저장되도록 변경하기

## 🔁 변경 사항

- dev yml & local yml 수정
- Uploader 코드 수정

## 📸 스크린샷
+ 로컬 yml에는 localhost:8080 붙어서 저장되는 것 확인 했습니다! dev yml도 배포 링크 붙어서 저장 되도록 했습니다!
<img width="2329" height="290" alt="image" src="https://github.com/user-attachments/assets/2fc86b4d-7ae7-42b2-904a-24935489631f" />

## 👀 기타 더 이야기해볼 점
